### PR TITLE
treeview: Unnest main body of sub

### DIFF
--- a/texapp-treeview.pm
+++ b/texapp-treeview.pm
@@ -13,7 +13,7 @@ $addaction = sub {
 	return 0 unless ($command =~ s#^/tree ## && length($command));
 
 	my $post = &get_post($command);
-	if (!$post->{'id'}) {
+	unless ($post->{'id'}) {
 		&std(" -- sorry, no such post (yet?): $command\n");
 		return 1;
 	}

--- a/texapp-treeview.pm
+++ b/texapp-treeview.pm
@@ -13,11 +13,12 @@ $addaction = sub {
 	return 0 unless ($command =~ s#^/tree ## && length($command));
 
 	my $post = &get_post($command);
-	unless ($post->{'id'}) {
+	my $canonical_id = $post->{'id'};
+	unless ($canonical_id) {
 		&std(" -- sorry, no such post (yet?): $command\n");
 		return 1;
 	}
-	my $canonical_id = $post->{'id'};
+
 	# I use the following command, because I call an external script with
 	# urlopen in .texapprc:
 	#

--- a/texapp-treeview.pm
+++ b/texapp-treeview.pm
@@ -12,8 +12,7 @@ $addaction = sub {
 
 	return 0 unless ($command =~ s#^/tree ## && length($command));
 
-	my $post = &get_post($command);
-	my $canonical_id = $post->{'id'};
+	my $canonical_id = &get_post($command)->{'id'};
 	unless ($canonical_id) {
 		&std(" -- sorry, no such post (yet?): $command\n");
 		return 1;

--- a/texapp-treeview.pm
+++ b/texapp-treeview.pm
@@ -10,22 +10,20 @@
 $addaction = sub {
 	my $command = shift;
 
-	if ($command =~ s#^/tree ## && length($command)) {
-		my $post = &get_post($command);
-		if (!$post->{'id'}) {
-			&std(" -- sorry, no such post (yet?): $command\n");
-			return 1;
-		}
-		my $canonical_id = $post->{'id'};
-		# I use the following command, because I call an external script with
-		# urlopen in .texapprc:
-		#
-		# system "xdg-open", "http://treeview.us/home/Form?postID=$canonical_id";
-		#
-		# You'll probably want this:
-		&openurl("http://treeview.us/home/Form?postID=$canonical_id");
+	return 0 unless ($command =~ s#^/tree ## && length($command));
+
+	my $post = &get_post($command);
+	if (!$post->{'id'}) {
+		&std(" -- sorry, no such post (yet?): $command\n");
 		return 1;
 	}
-
-	return 0;
+	my $canonical_id = $post->{'id'};
+	# I use the following command, because I call an external script with
+	# urlopen in .texapprc:
+	#
+	# system "xdg-open", "http://treeview.us/home/Form?postID=$canonical_id";
+	#
+	# You'll probably want this:
+	&openurl("http://treeview.us/home/Form?postID=$canonical_id");
+	return 1;
 };


### PR DESCRIPTION
Bail early as part of input validation.

Parentheses around trailing unless condition might be unnecessary.

Feels like the canonical_id validation should be able to be cleaned up,
too, but I'm not confident enough in my Perl to try that without running
it first. :)